### PR TITLE
update failure mode

### DIFF
--- a/Arduino/arduino_car_controller/arduino_car_controller.ino
+++ b/Arduino/arduino_car_controller/arduino_car_controller.ino
@@ -84,10 +84,8 @@ void loop() {
     turn_angle = 100 * instruction[3] + 10 * instruction[4] + instruction[5];
 
     // If values are out of bounds, assume error and return to neutral position
-    if ((drive_speed>180) || (drive_speed<0)){
+    if ( (drive_speed>180) || (drive_speed<0) || (turn_angle>180) || (turn_angle<0) ){
       drive_speed = 90;
-    }
-    if ((turn_angle>180) || (turn_angle<0)){
       turn_angle = 90;
     }
 


### PR DESCRIPTION
Suggest updating the out-of-range failure mode to reset both drive AND steering values if either one is out of range. This way the car will always stop if ether value is out of range.